### PR TITLE
Add basic financial analysis web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+instance/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# app-ratios
+# Aplicación de Análisis Financiero
+
+Esta aplicación permite subir un archivo CSV o Excel con información contable y calcula diversos indicadores financieros. Los resultados se muestran en un dashboard con semáforo y se pueden exportar a PDF.
+
+## Uso
+
+1. Instale las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ejecute la aplicación:
+   ```bash
+   python app.py
+   ```
+3. Abra su navegador en `http://localhost:5000` y cargue su archivo.
+
+El archivo debe contener columnas con los siguientes encabezados (en español):
+`Activo Corriente`, `Pasivo Corriente`, `Inventarios`, `Pasivo Total`, `Activo Total`, `Patrimonio Neto`, `Utilidad Neta`, `Ventas Totales`, `Costo de Ventas`, `Inventarios Promedio`, `Ventas a Crédito`, `Cuentas por Cobrar Promedio`, `Utilidad Operativa`, `Capitalizacion de Mercado`, `Deuda Neta`, `Efectivo`, `Cuentas por Cobrar`, `Ventas Diarias Promedio`, `Cuentas por Pagar`, `Compras Diarias Promedio`.
+
+## PDF
+
+Para generar el PDF se utiliza `pdfkit`, que requiere tener instalado `wkhtmltopdf` en el sistema.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+from . import routes

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,150 @@
+import io
+import pandas as pd
+from flask import render_template, request, redirect, url_for, send_file
+from . import app
+
+# Thresholds for traffic light indicator
+THRESHOLDS = {
+    'razon_corriente': [1, 2],  # <1 rojo, 1-2 amarillo, >2 verde
+    'prueba_acida': [0.8, 1],
+    'razon_endeudamiento': [0.5, 0.8],
+    'roe': [0.1, 0.2],
+    'roa': [0.05, 0.1],
+}
+
+RECOMMENDATIONS = {
+    'razon_corriente': {
+        'low': 'Riesgo de iliquidez. Considere reducir pasivos o aumentar caja.',
+        'high': 'Capital de trabajo ocioso. Considere invertir excedentes.'
+    },
+    'prueba_acida': {
+        'low': 'Inventarios altos pueden ocultar problemas de liquidez.',
+        'high': 'Buena cobertura de corto plazo.'
+    },
+}
+
+
+def get_color(value, thresholds):
+    low, high = thresholds
+    if value < low:
+        return 'red'
+    if low <= value <= high:
+        return 'yellow'
+    return 'green'
+
+
+def compute_ratios(df):
+    ratios = {}
+    try:
+        ratios['razon_corriente'] = df['Activo Corriente'].iloc[0] / df['Pasivo Corriente'].iloc[0]
+    except Exception:
+        ratios['razon_corriente'] = None
+    try:
+        ratios['prueba_acida'] = (
+            df['Activo Corriente'].iloc[0] - df['Inventarios'].iloc[0]
+        ) / df['Pasivo Corriente'].iloc[0]
+    except Exception:
+        ratios['prueba_acida'] = None
+    try:
+        ratios['capital_trabajo'] = df['Activo Corriente'].iloc[0] - df['Pasivo Corriente'].iloc[0]
+    except Exception:
+        ratios['capital_trabajo'] = None
+    try:
+        ratios['razon_endeudamiento'] = df['Pasivo Total'].iloc[0] / df['Activo Total'].iloc[0]
+    except Exception:
+        ratios['razon_endeudamiento'] = None
+    try:
+        ratios['razon_deuda_patrimonio'] = df['Pasivo Total'].iloc[0] / df['Patrimonio Neto'].iloc[0]
+    except Exception:
+        ratios['razon_deuda_patrimonio'] = None
+    try:
+        ratios['roe'] = (df['Utilidad Neta'].iloc[0] / df['Patrimonio Neto'].iloc[0]) * 100
+    except Exception:
+        ratios['roe'] = None
+    try:
+        ratios['roa'] = (df['Utilidad Neta'].iloc[0] / df['Activo Total'].iloc[0]) * 100
+    except Exception:
+        ratios['roa'] = None
+    try:
+        ratios['margen_utilidad_neta'] = (df['Utilidad Neta'].iloc[0] / df['Ventas Totales'].iloc[0]) * 100
+    except Exception:
+        ratios['margen_utilidad_neta'] = None
+    try:
+        ratios['rotacion_activos'] = df['Ventas Totales'].iloc[0] / df['Activo Total'].iloc[0]
+    except Exception:
+        ratios['rotacion_activos'] = None
+    try:
+        ratios['rotacion_inventarios'] = df['Costo de Ventas'].iloc[0] / df['Inventarios Promedio'].iloc[0]
+    except Exception:
+        ratios['rotacion_inventarios'] = None
+    try:
+        ratios['rotacion_cxc'] = df['Ventas a Crédito'].iloc[0] / df['Cuentas por Cobrar Promedio'].iloc[0]
+    except Exception:
+        ratios['rotacion_cxc'] = None
+    try:
+        ratios['margen_operativo'] = (df['Utilidad Operativa'].iloc[0] / df['Ventas Totales'].iloc[0]) * 100
+    except Exception:
+        ratios['margen_operativo'] = None
+    try:
+        ratios['valor_empresa'] = (
+            df['Capitalizacion de Mercado'].iloc[0]
+            + df['Deuda Neta'].iloc[0]
+            - df['Efectivo'].iloc[0]
+        )
+    except Exception:
+        ratios['valor_empresa'] = None
+    try:
+        ratios['dias_cxc'] = df['Cuentas por Cobrar'].iloc[0] / df['Ventas Diarias Promedio'].iloc[0]
+    except Exception:
+        ratios['dias_cxc'] = None
+    try:
+        ratios['dias_cxp'] = df['Cuentas por Pagar'].iloc[0] / df['Compras Diarias Promedio'].iloc[0]
+    except Exception:
+        ratios['dias_cxp'] = None
+    return ratios
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file:
+            return redirect(url_for('index'))
+        if file.filename.endswith('.csv'):
+            df = pd.read_csv(file)
+        else:
+            df = pd.read_excel(file)
+        ratios = compute_ratios(df)
+        colors = {
+            key: get_color(val, THRESHOLDS.get(key, [0, 0])) if val is not None else 'grey'
+            for key, val in ratios.items()
+        }
+        recs = {}
+        for key, val in ratios.items():
+            thresh = THRESHOLDS.get(key)
+            if val is None or thresh is None:
+                continue
+            low, high = thresh
+            if val < low:
+                recs[key] = RECOMMENDATIONS.get(key, {}).get('low')
+            elif val > high:
+                recs[key] = RECOMMENDATIONS.get(key, {}).get('high')
+        return render_template('dashboard.html', ratios=ratios, colors=colors, recs=recs)
+    return render_template('index.html')
+
+
+@app.route('/download', methods=['POST'])
+def download_pdf():
+    from flask import render_template_string
+    import pdfkit
+
+    data = request.form.to_dict(flat=False)
+    ratios = {k: float(v[0]) if v else None for k, v in data.items() if k.startswith('ratio_')}
+    html = render_template('pdf.html', ratios=ratios)
+    pdf = pdfkit.from_string(html, False)
+    return send_file(
+        io.BytesIO(pdf),
+        as_attachment=True,
+        download_name='resumen.pdf',
+        mimetype='application/pdf'
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pandas
+openpyxl
+pdfkit

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,43 @@
+{% extends 'layout.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Resultados</h1>
+<div class="mb-4">
+    <form action="{{ url_for('download_pdf') }}" method="post">
+        {% for key, val in ratios.items() %}
+            <input type="hidden" name="ratio_{{ key }}" value="{{ val }}">
+        {% endfor %}
+        <button class="bg-green-600 text-white px-4 py-2 rounded" type="submit">Descargar PDF</button>
+    </form>
+</div>
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    {% for key, val in ratios.items() %}
+        <div class="p-4 bg-white shadow rounded">
+            <h3 class="font-semibold mb-2">{{ key.replace('_', ' ')|title }}</h3>
+            {% if val is not none %}
+            <p class="text-xl font-bold">{{ '%.2f'|format(val) }}</p>
+            <span class="inline-block px-2 py-1 text-white rounded bg-{{ colors[key] }}-500">{{ colors[key] }}</span>
+            {% if recs.get(key) %}
+                <p class="mt-2 text-sm text-red-700">{{ recs[key] }}</p>
+            {% endif %}
+            {% else %}
+            <p>No disponible</p>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>
+<div class="mt-8" id="charts"></div>
+<script>
+const data = {
+    labels: {{ ratios.keys()|list }},
+    datasets: [{
+        label: 'Ratios',
+        data: {{ ratios.values()|list }},
+        backgroundColor: 'rgba(54, 162, 235, 0.5)'
+    }]
+};
+const ctx = document.createElement('canvas');
+document.getElementById('charts').appendChild(ctx);
+new Chart(ctx, {type: 'bar', data});
+</script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block title %}Subir archivo{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Análisis Financiero</h1>
+<form method="post" enctype="multipart/form-data" class="bg-white p-6 rounded shadow-md">
+    <label class="block mb-2">Seleccione archivo CSV o Excel</label>
+    <input type="file" name="file" accept=".csv,.xls,.xlsx" class="border p-2 mb-4 w-full" required>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Subir</button>
+</form>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Finanzas{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100">
+    <div class="container mx-auto p-4">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/pdf.html
+++ b/templates/pdf.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Resumen Financiero</title>
+<style>
+body { font-family: sans-serif; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #333; padding: 4px; text-align: left; }
+</style>
+</head>
+<body>
+<h1>Resumen de Ratios</h1>
+<table>
+<tr><th>Ratio</th><th>Valor</th></tr>
+{% for key, val in ratios.items() %}
+<tr>
+    <td>{{ key.replace('_', ' ') }}</td>
+    <td>{{ '%.2f'|format(val) if val is not none else 'N/A' }}</td>
+</tr>
+{% endfor %}
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement Flask application to calculate financial ratios
- add HTML templates for upload form, dashboard and PDF export
- include Tailwind and Chart.js for styling and charts
- provide PDF generation using pdfkit
- document usage in README

## Testing
- `python -m py_compile app.py app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685740d0b0b48324979813ebf81e2598